### PR TITLE
Add Icinga Notifications integration

### DIFF
--- a/library/Kubernetes/Model/Config.php
+++ b/library/Kubernetes/Model/Config.php
@@ -1,0 +1,32 @@
+<?php
+
+/* Icinga for Kubernetes Web | (c) 2024 Icinga GmbH | AGPLv3 */
+
+namespace Icinga\Module\Kubernetes\Model;
+
+use ipl\Orm\Model;
+
+/**
+ * @property string $key Arbitrary unique config key
+ * @property string $value The actual config value
+ */
+class Config extends Model
+{
+    public function getTableName(): string
+    {
+        return 'config';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'key';
+    }
+
+    public function getColumns(): array
+    {
+        return [
+            'key',
+            'value'
+        ];
+    }
+}

--- a/library/Kubernetes/ProvidedHook/AutoPopulateSource.php
+++ b/library/Kubernetes/ProvidedHook/AutoPopulateSource.php
@@ -1,0 +1,192 @@
+<?php
+
+/* Icinga for Kubernetes Web | (c) 2024 Icinga GmbH | AGPLv3 */
+
+namespace Icinga\Module\Kubernetes\ProvidedHook;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Icinga\Application\Hook\ApplicationStateHook;
+use Icinga\Application\Logger;
+use Icinga\Module\Kubernetes\Common\Database;
+use Icinga\Module\Kubernetes\Model\Config;
+use Icinga\Module\Notifications\Forms\SourceForm;
+use ipl\Stdlib\Filter;
+use Throwable;
+
+class AutoPopulateSource extends ApplicationStateHook
+{
+    protected const DEFAULT_SOURCE_USER = 'Icinga for Kubernetes';
+
+    public function collectMessages()
+    {
+        $config = \Icinga\Application\Config::module('kubernetes');
+        if (! $config->get('settings', 'auto_create_notifications_source', false)) {
+            return;
+        }
+
+        $config = Config::on(Database::connection());
+        $config->filter(
+            Filter::any(
+                Filter::equal('key', 'notifications.username'),
+                Filter::equal('key', 'notifications.password'),
+                Filter::equal('key', 'notifications.source_id')
+            )
+        );
+
+        $username = null;
+        $password = null;
+        $sourceID = null;
+        foreach ($config as $pair) {
+            if ($pair->key === 'notifications.username') {
+                $username = $pair->value;
+            }
+            if ($pair->key === 'notifications.password') {
+                $password = $pair->value;
+            }
+            if ($pair->key === 'notifications.source_id') {
+                $sourceID = (int)$pair->value;
+            }
+        }
+
+        $sourceForm = new class (\Icinga\Module\Notifications\Common\Database::get()) extends SourceForm {
+            public function hasBeenSubmitted()
+            {
+                return $this->hasBeenSent(); // Cheating :)
+            }
+        };
+
+        if ($sourceID !== null) {
+            $sourceForm->loadSource($sourceID);
+        }
+
+        if ($password !== null && $username == static::DEFAULT_SOURCE_USER) {
+            $data = [
+                'listener_password'      => $password,
+                'listener_password_dupe' => $password,
+            ];
+
+            if ($sourceID === null) {
+                $data ['name'] = static::DEFAULT_SOURCE_USER;
+                $data ['type'] = 'kubernetes';
+                $data ['icinga2_insecure_tls'] = 'n';
+            }
+
+            $sourceForm
+                ->populate($data)
+                ->on(SourceForm::ON_SUCCESS, function (SourceForm $form) use ($sourceID) {
+                    if ($sourceID !== null) {
+                        try {
+                            $form->editSource();
+                        } catch (Throwable $err) {
+                            $this->addError(
+                                'kubernetes.source.error',
+                                time(),
+                                'Failed to automatically update Icinga for Kubernetes notifications source'
+                                . ', see logs for details!'
+                            );
+
+                            Logger::error(
+                                'Failed to automatically update Icinga for Kubernetes notifications source: %s',
+                                $err
+                            );
+                            Logger::debug($err->getTraceAsString());
+                        }
+                    } else {
+                        try {
+                            $form->addSource();
+                        } catch (Throwable $err) {
+                            $this->addError(
+                                'kubernetes.source.error',
+                                time(),
+                                'Failed to automatically populate Icinga for Kubernetes notifications source'
+                                . ', see logs for details!'
+                            );
+
+                            Logger::error(
+                                'Failed to automatically populate Icinga for Kubernetes notifications source: %s',
+                                $err
+                            );
+                            Logger::debug($err->getTraceAsString());
+
+                            return;
+                        }
+
+                        try {
+                            $sourceId = \Icinga\Module\Notifications\Common\Database::get()->lastInsertid();
+                            $db = Database::connection();
+                            $db->insert('config', [
+                                $db->quoteIdentifier('key') => 'notifications.source_id',
+                                'value'                     => $sourceId,
+                            ]);
+                        } catch (Throwable $err) {
+                            $this->addError(
+                                'kubernetes.source.error',
+                                time(),
+                                'Failed to insert Icinga for Kubernetes notifications source ID, see logs for details!'
+                            );
+
+                            Logger::error('Failed to insert Icinga for Kubernetes notifications source ID: %s', $err);
+                            Logger::debug($err->getTraceAsString());
+                        }
+                    }
+                });
+        } elseif ($sourceID !== null && $password === null) {
+            $sourceForm
+                ->on(SourceForm::ON_SUCCESS, function (SourceForm $form) {
+                    try {
+                        $form->removeSource();
+                    } catch (Throwable $err) {
+                        $this->addError(
+                            'kubernetes.source.error',
+                            time(),
+                            'Failed to remove auto generated Icinga for Kubernetes notifications source'
+                            . ', see logs for details!'
+                        );
+
+                        Logger::error(
+                            'Failed to remove auto generated Icinga for Kubernetes notifications source: %s',
+                            $err
+                        );
+                        Logger::debug($err->getTraceAsString());
+                    }
+
+                    try {
+                        $db = Database::connection();
+                        $db->delete('config', ["{$db->quoteIdentifier('key')} = ?" => 'notifications.source_id']);
+                    } catch (Throwable $err) {
+                        $this->addError(
+                            'kubernetes.source.error',
+                            time(),
+                            'Failed to delete Icinga for Kubernetes notifications source ID, see logs for details!'
+                        );
+
+                        Logger::error('Failed to delete Icinga for Kubernetes notifications source ID: %s', $err);
+                        Logger::debug($err->getTraceAsString());
+                    }
+                });
+        }
+
+        // Again cheating to match the server request and our source form method.
+        $orgRequestMethod = $_SERVER['REQUEST_METHOD'];
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $request = ServerRequest::fromGlobals();
+        $_SERVER['REQUEST_METHOD'] = $orgRequestMethod;
+
+        try {
+            $sourceForm->ensureAssembled();
+            $csrf = $sourceForm->getElement('CSRFToken');
+            if (preg_match('/ value="([^"]+)/', $csrf->getAttributes()->render(), $matches)) {
+                // CSRF token validation was changed in the meantime, so that it always triggers the validation,
+                // even without a populated token, so we need to workaround it here.
+                $csrf->setValue($matches[1]);
+            }
+
+            $sourceForm->handleRequest($request);
+        } catch (Throwable $err) {
+            $this->addError('kubernetes.source.error', time(), $err->getMessage());
+
+            Logger::error($err);
+            Logger::debug($err->getTraceAsString());
+        }
+    }
+}

--- a/library/Kubernetes/ProvidedHook/Notifications/ObjectsRenderer.php
+++ b/library/Kubernetes/ProvidedHook/Notifications/ObjectsRenderer.php
@@ -1,0 +1,206 @@
+<?php
+
+/* Icinga for Kubernetes Web | (c) 2024 Icinga GmbH | AGPLv3 */
+
+namespace Icinga\Module\Kubernetes\ProvidedHook\Notifications;
+
+use Generator;
+use Icinga\Module\Kubernetes\Web\Factory;
+use Icinga\Module\Notifications\Hook\ObjectsRendererHook;
+use ipl\Html\Attributes;
+use ipl\Html\FormattedString;
+use ipl\Html\Html;
+use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+use ipl\Html\ValidHtml;
+use ipl\I18n\Translation;
+use ipl\Stdlib\Filter;
+use ipl\Web\Widget\Icon;
+use Ramsey\Uuid\Uuid;
+
+class ObjectsRenderer extends ObjectsRendererHook
+{
+    use Translation;
+
+    public function getObjectNames(array $objectIdTags): Generator
+    {
+        yield from $this->yieldObjectsResults($objectIdTags, false);
+    }
+
+    public function getHtmlForObjectNames(array $objectIdTags): Generator
+    {
+        yield from $this->yieldObjectsResults($objectIdTags, true);
+    }
+
+    public function getSourceType(): string
+    {
+        return 'kubernetes';
+    }
+
+    public function createObjectLink(array $objectIdTag): ?ValidHtml
+    {
+        if (! isset($objectIdTag['resource']) || ! isset($objectIdTag['uuid'])) {
+            return null;
+        }
+
+        return Factory::createList(
+            $objectIdTag['resource'],
+            Filter::equal('uuid', Uuid::fromString($objectIdTag['uuid'])->getBytes())
+        );
+    }
+
+    /**
+     * Yield objects names formatted in {@see FormattedString HTML} or plain string based on the `$asHtml` param.
+     *
+     * @param array<array<string, string>> $objectIdTags A list of object ID tags of Icinga for Kubernetes objects
+     * @param bool $asHtml Whether to yield the formatted objects names in HTML string
+     *
+     * @return Generator<array<string, string>, string> Yields the formatted objects names wither their ID tags as keys
+     */
+    protected function yieldObjectsResults(array $objectIdTags, bool $asHtml): Generator
+    {
+        foreach ($objectIdTags as $idTags) {
+            if (! isset($idTags['resource']) || ! isset($idTags['name'])) {
+                continue;
+            }
+
+            switch ($idTags['resource']) {
+                case 'pod':
+                    if (! $asHtml) {
+                        yield $idTags => sprintf(
+                            $this->translate('%s - %s', '<namespace> - <name>'),
+                            $idTags['namespace'],
+                            $idTags['name']
+                        );
+                    } else {
+                        yield $idTags => Html::sprintf(
+                            $this->translate('%s', '<pod>'),
+                            [
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'namespace-badge']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-namespace'])),
+                                    new Text($idTags['namespace'])
+                                ),
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'subject']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-pod'])),
+                                    new Text($idTags['name'])
+                                )
+                            ]
+                        );
+                    }
+
+                    break;
+                case 'deployment':
+                    if (! $asHtml) {
+                        yield $idTags => sprintf($this->translate('%s', '<deployment>'), $idTags['name']);
+                    } else {
+                        yield $idTags => Html::sprintf(
+                            $this->translate('%s', '<deployment>'),
+                            [
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'namespace-badge']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-namespace'])),
+                                    new Text($idTags['namespace'])
+                                ),
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'subject']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-deployment'])),
+                                    new Text($idTags['name'])
+                                )
+                            ]
+                        );
+                    }
+
+                    break;
+                case 'node':
+                    if (! $asHtml) {
+                        yield $idTags => sprintf($this->translate('%s', '<node>'), $idTags['name']);
+                    } else {
+                        yield $idTags => Html::sprintf(
+                            $this->translate('%s', '<node>'),
+                            new HtmlElement(
+                                'span',
+                                new Attributes(['class' => 'subject']),
+                                new Icon('share-nodes'),
+                                new Text($idTags['name'])
+                            )
+                        );
+                    }
+                    break;
+                case 'daemon_set':
+                    if (! $asHtml) {
+                        yield $idTags => sprintf($this->translate('%s', '<daemon_set>'), $idTags['name']);
+                    } else {
+                        yield $idTags => Html::sprintf(
+                            $this->translate('%s', '<daemon_set>'),
+                            [
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'namespace-badge']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-namespace'])),
+                                    new Text($idTags['namespace'])
+                                ),
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'subject']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-daemon-set'])),
+                                    new Text($idTags['name'])
+                                )
+                            ]
+                        );
+                    }
+                    break;
+                case 'replica_set':
+                    if (! $asHtml) {
+                        yield $idTags => sprintf($this->translate('%s', '<replica_set>'), $idTags['name']);
+                    } else {
+                        yield $idTags => Html::sprintf(
+                            $this->translate('%s', '<replica_set>'),
+                            [
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'namespace-badge']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-namespace'])),
+                                    new Text($idTags['namespace'])
+                                ),
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'subject']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-replica-set'])),
+                                    new Text($idTags['name'])
+                                )
+                            ]
+                        );
+                    }
+                    break;
+                case 'stateful_set':
+                    if (! $asHtml) {
+                        yield $idTags => sprintf($this->translate('%s', '<stateful_set>'), $idTags['name']);
+                    } else {
+                        yield $idTags => Html::sprintf(
+                            $this->translate('%s is %s', '<stateful_set> is <icinga_state>'),
+                            [
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'namespace-badge']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-namespace'])),
+                                    new Text($idTags['namespace'])
+                                ),
+                                new HtmlElement(
+                                    'span',
+                                    new Attributes(['class' => 'subject']),
+                                    new HtmlElement('i', new Attributes(['class' => 'icon kicon-stateful-set'])),
+                                    new Text($idTags['name'])
+                                )
+                            ]
+                        );
+                    }
+            }
+        }
+    }
+}

--- a/public/css/lists.less
+++ b/public/css/lists.less
@@ -47,6 +47,12 @@ footer {
   max-width: 8em;
   padding: 0 .25em;
   vertical-align: baseline;
+
+  // Namespace badges are wrapped by an "a" HTML tag when rendered in Icinga Notifications via the object
+  // renderer hook, which forces the font weight to bold and the text colour to the default text one, making
+  // the lists look different within Icinga Notification than in Icinga for Kubernetes.
+  font-weight: normal;
+  color: @text-color-light;
 }
 
 .caption {

--- a/run.php
+++ b/run.php
@@ -17,3 +17,9 @@ if (! function_exists('yield_iterable')) {
         }
     }
 }
+
+/** @var $this \Icinga\Application\Modules\Module */
+
+if ($this::exists('notifications')) {
+    $this->provideHook('ApplicationState', 'AutoPopulateSource');
+}

--- a/run.php
+++ b/run.php
@@ -22,4 +22,5 @@ if (! function_exists('yield_iterable')) {
 
 if ($this::exists('notifications')) {
     $this->provideHook('ApplicationState', 'AutoPopulateSource');
+    $this->provideHook('Notifications/ObjectsRenderer');
 }


### PR DESCRIPTION
This PR adds support for Icinga Notifications.

- Allows to automatically manage the [source](https://icinga.com/docs/icinga-notifications-web/latest/doc/03-Configuration/#sources-configuration) entry for Icinga for Kubernetes if you explicitly request it to do so via the new `auto_create_notifications_source` configuration option.
- Implements the `ObjectRenderer` hook to render all our source objects lazily in a nice and structured way. In order for this hook to become active, one has to use `kubernetes` as source type (for automatically created sources it is set correctly), otherwise this hook will not trigger any actions.