### PR TITLE
Links: Fix replica set base url

### DIFF
--- a/library/Kubernetes/Common/Links.php
+++ b/library/Kubernetes/Common/Links.php
@@ -99,7 +99,7 @@ abstract class Links
 
     public static function replicaSet(ReplicaSet $replicaSet): Url
     {
-        return Url::fromPath('kubernetes/replicaSet', ['id' => (string) Uuid::fromBytes($replicaSet->uuid)]);
+        return Url::fromPath('kubernetes/replicaset', ['id' => (string) Uuid::fromBytes($replicaSet->uuid)]);
     }
 
     public static function secret(Secret $secret): Url


### PR DESCRIPTION
The URLs should either be in small case or separated by a `-`, but since e.g. for `Daemon Set` is already set to lower case `daemonset`, this PR also sets Replica Set to lower case.