### PR TITLE
Add config tab for Prometheus and multi-cluster support

### DIFF
--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -4,7 +4,6 @@
 
 namespace Icinga\Module\Kubernetes\Controllers;
 
-use Exception;
 use GuzzleHttp\Psr7\ServerRequest;
 use Icinga\Application\Config;
 use Icinga\Application\Logger;
@@ -22,6 +21,7 @@ use Icinga\Web\Notification;
 use Icinga\Web\Widget\Tabs;
 use ipl\Sql\Connection;
 use ipl\Stdlib\Filter;
+use ipl\Web\Url;
 use LogicException;
 use Ramsey\Uuid\Uuid;
 use Throwable;
@@ -73,8 +73,8 @@ class ConfigController extends Controller
         };
 
         try {
-
             $form = (new NotificationsConfigForm())
+                ->populate(['cluster_uuid' => $this->getRequest()->get('id')])
                 ->on(
                     NotificationsConfigForm::ON_SUCCESS,
                     function (NotificationsConfigForm $form) use ($sourceForm) {
@@ -151,7 +151,7 @@ class ConfigController extends Controller
                             $this->translate('New configuration has successfully been stored.')
                         );
 
-                        $this->redirectNow('__REFRESH__');
+                        $this->redirectNow(Url::fromPath('kubernetes/config/notifications', ['id' => $clusterUuid]));
                     }
                 )->handleRequest($this->getServerRequest());
 
@@ -182,6 +182,7 @@ class ConfigController extends Controller
     public function prometheusAction()
     {
         $form = (new PrometheusConfigForm())
+            ->populate(['cluster_uuid' => $this->getRequest()->get('id')])
             ->on(PrometheusConfigForm::ON_SUCCESS, function (PrometheusConfigForm $form) {
                 if ($form->isLocked()) {
                     $form->addMessage($this->translate('Prometheus configuration is locked.'));
@@ -222,7 +223,7 @@ class ConfigController extends Controller
                 }
 
                 Notification::success($this->translate('New configuration has successfully been stored'));
-                $this->redirectNow('__REFRESH__');
+                $this->redirectNow(Url::fromPath('kubernetes/config/prometheus', ['id' => $clusterUuid]));
             })->handleRequest($this->getServerRequest());
 
         $this->mergeTabs($this->Module()->getConfigTabs()->activate('prometheus'));

--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -7,7 +7,6 @@ namespace Icinga\Module\Kubernetes\Controllers;
 use GuzzleHttp\Psr7\ServerRequest;
 use Icinga\Application\Config;
 use Icinga\Application\Logger;
-use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Kubernetes\Common\Database;
 use Icinga\Module\Kubernetes\Forms\DatabaseConfigForm;
 use Icinga\Module\Kubernetes\Forms\NotificationsConfigForm;
@@ -56,8 +55,6 @@ class ConfigController extends Controller
 
     public function notificationsAction()
     {
-        // Check sources in use, maybe list them, delete unused automatically with a checkbox or something.
-        // Add cluster uuid to username.
         $this->mergeTabs($this->Module()->getConfigTabs()->activate('notifications'));
 
         $sourceForm = new class (NotificationsDatabase::get()) extends SourceForm {
@@ -72,105 +69,98 @@ class ConfigController extends Controller
             }
         };
 
-        try {
-            $form = (new NotificationsConfigForm())
-                ->populate(['cluster_uuid' => $this->getRequest()->get('id')])
-                ->on(
-                    NotificationsConfigForm::ON_SUCCESS,
-                    function (NotificationsConfigForm $form) use ($sourceForm) {
-                        if ($form->isLocked()) {
-                            $form->addMessage($this->translate('Notifications configuration is locked.'));
+        $form = (new NotificationsConfigForm())
+            ->populate(['cluster_uuid' => $this->getRequest()->get('id')])
+            ->on(
+                NotificationsConfigForm::ON_SUCCESS,
+                function (NotificationsConfigForm $form) use ($sourceForm) {
+                    if ($form->isLocked()) {
+                        $form->addMessage($this->translate('Notifications configuration is locked.'));
 
-                            return;
-                        }
+                        return;
+                    }
 
-                        $clusterUuid = $form->getClusterUuid();
-                        $kconfig = $form->getKConfig($clusterUuid);
-                        $values = $form->getValues();
+                    $clusterUuid = $form->getClusterUuid();
+                    $kconfig = $form->getKConfig($clusterUuid);
+                    $values = $form->getValues();
 
-                        if (
-                            ! ($kconfig[KConfig::NOTIFICATIONS_USERNAME]->locked ?? false)
-                            && ($kconfig[KConfig::NOTIFICATIONS_USERNAME]->value ?? '') === ''
-                        ) {
-                            try {
-                                $values[KConfig::NOTIFICATIONS_PASSWORD] = $this->createSource($sourceForm, $clusterUuid);
-                            } catch (Throwable $e) {
-                                Logger::error($e);
-                                Logger::error($e->getTraceAsString());
+                    /** @var ?Source $source */
+                    $source = Source::on(NotificationsDatabase::get())
+                        ->filter(Filter::all(
+                            Filter::equal('name', KConfig::DEFAULT_NOTIFICATIONS_NAME . " ($clusterUuid)"),
+                            Filter::equal('type', KConfig::DEFAULT_NOTIFICATIONS_TYPE)
+                        ))
+                        ->first();
 
-                                throw $e;
-                            }
+                    if (
+                        $source === null
+                        // Must be kept in sync with SourceForm:292.
+                        || password_hash(
+                            $kconfig[KConfig::NOTIFICATIONS_PASSWORD]->value,
+                            SourceForm::HASH_ALGORITHM
+                        ) !== $source->listener_password_hash
+                    ) {
+                        try {
+                            $values[KConfig::NOTIFICATIONS_PASSWORD] = $this
+                                ->createOrUpdateSource($sourceForm, $clusterUuid);
 
                             /** @var ?Source $source */
                             $source = Source::on(NotificationsDatabase::get())
                                 ->filter(Filter::all(
-                                    Filter::equal('name', KConfig::DEFAULT_NOTIFICATIONS_NAME . "($clusterUuid)"),
+                                    Filter::equal('name', KConfig::DEFAULT_NOTIFICATIONS_NAME . " ($clusterUuid)"),
                                     Filter::equal('type', KConfig::DEFAULT_NOTIFICATIONS_TYPE)
                                 ))
                                 ->first();
 
                             if ($source === null) {
-                                throw new LogicException($this->translate('Source not found'));
+                                throw new LogicException($this->translate('Source not created'));
                             }
 
                             $values[KConfig::NOTIFICATIONS_USERNAME] = "source-$source->id";
-                        }
-
-                        try {
-                            Database::connection()->transaction(function (Connection $db) use ($values, $clusterUuid) {
-                                $db->delete((new KConfig())->getTableName(), [
-                                    'cluster_uuid = ?'                                => Uuid::fromString($clusterUuid)->getBytes(),
-                                    sprintf('%s IN (?)', $db->quoteIdentifier('key')) => array_keys($values),
-                                    'locked = ?'                                      => 'n'
-                                ]);
-
-                                foreach ($values as $k => $v) {
-                                    if (empty($v)) {
-                                        continue;
-                                    }
-
-                                    $db->insert((new KConfig())->getTableName(), [
-                                        'cluster_uuid'              => Uuid::fromString($clusterUuid)->getBytes(),
-                                        $db->quoteIdentifier('key') => $k,
-                                        'value'                     => $v
-                                    ]);
-                                }
-                            });
                         } catch (Throwable $e) {
                             Logger::error($e);
                             Logger::error($e->getTraceAsString());
 
                             throw $e;
                         }
-
-                        Notification::success(
-                            $this->translate('New configuration has successfully been stored.')
-                        );
-
-                        $this->redirectNow(Url::fromPath('kubernetes/config/notifications', ['id' => $clusterUuid]));
                     }
-                )->handleRequest($this->getServerRequest());
 
-            if (
-                preg_match(
-                    '/source-(\d+)/',
-                    $kconfig[KConfig::NOTIFICATIONS_USERNAME]->value ?? '',
-                    $matches
-                ) !== false
-                && ! empty($matches)
-            ) {
-                try {
-                    $sourceForm->loadSource($matches[1]);
+                    try {
+                        Database::connection()->transaction(function (Connection $db) use ($values, $clusterUuid) {
+                            $key = $db->quoteIdentifier('key');
 
-                    // TODO(el): Check password mismatch.
-                } catch (HttpNotFoundException $e) {
-                    // TODO(el): Add error box.
+                            $db->delete((new KConfig())->getTableName(), [
+                                'cluster_uuid = ?'         => Uuid::fromString($clusterUuid)->getBytes(),
+                                sprintf('%s IN (?)', $key) => array_keys($values),
+                                'locked = ?'               => 'n'
+                            ]);
+
+                            foreach ($values as $k => $v) {
+                                if (empty($v)) {
+                                    continue;
+                                }
+
+                                $db->insert((new KConfig())->getTableName(), [
+                                    'cluster_uuid' => Uuid::fromString($clusterUuid)->getBytes(),
+                                    $key           => $k,
+                                    'value'        => $v
+                                ]);
+                            }
+                        });
+                    } catch (Throwable $e) {
+                        Logger::error($e);
+                        Logger::error($e->getTraceAsString());
+
+                        throw $e;
+                    }
+
+                    Notification::success(
+                        $this->translate('New configuration has successfully been stored.')
+                    );
+
+                    $this->redirectNow(Url::fromPath('kubernetes/config/notifications', ['id' => $clusterUuid]));
                 }
-            }
-        } catch (Throwable $e) {
-            echo $e->getTraceAsString();
-            die;
-        }
+            )->handleRequest($this->getServerRequest());
 
         $this->addContent($form);
     }
@@ -191,10 +181,12 @@ class ConfigController extends Controller
 
                 try {
                     Database::connection()->transaction(function (Connection $db) use ($values, $clusterUuid) {
+                        $key = $db->quoteIdentifier('key');
+
                         $db->delete((new KConfig())->getTableName(), [
-                            'cluster_uuid = ?'                                => Uuid::fromString($clusterUuid)->getBytes(),
-                            sprintf('%s IN (?)', $db->quoteIdentifier('key')) => array_keys($values),
-                            'locked = ?'                                      => 'n'
+                            'cluster_uuid = ?'         => Uuid::fromString($clusterUuid)->getBytes(),
+                            sprintf('%s IN (?)', $key) => array_keys($values),
+                            'locked = ?'               => 'n'
                         ]);
 
                         foreach ($values as $k => $v) {
@@ -203,9 +195,9 @@ class ConfigController extends Controller
                             }
 
                             $db->insert((new KConfig())->getTableName(), [
-                                'cluster_uuid'              => Uuid::fromString($clusterUuid)->getBytes(),
-                                $db->quoteIdentifier('key') => $k,
-                                'value'                     => $v
+                                'cluster_uuid' => Uuid::fromString($clusterUuid)->getBytes(),
+                                $key           => $k,
+                                'value'        => $v
                             ]);
                         }
                     });
@@ -237,24 +229,42 @@ class ConfigController extends Controller
         }
     }
 
-    protected function createSource(SourceForm $sourceForm, string $clusterUuid): string
+    protected function createOrUpdateSource(SourceForm $sourceForm, string $clusterUuid): string
     {
         $password = sha1(openssl_random_pseudo_bytes(16));
 
         $formData = [
             'listener_password'      => $password,
             'listener_password_dupe' => $password,
-            'name'                   => KConfig::DEFAULT_NOTIFICATIONS_NAME . "($clusterUuid)",
+            'name'                   => KConfig::DEFAULT_NOTIFICATIONS_NAME . " ($clusterUuid)",
             'type'                   => KConfig::DEFAULT_NOTIFICATIONS_TYPE,
             // TODO(el): Why?
             'icinga2_insecure_tls'   => 'n'
         ];
 
-        $sourceForm
-            ->populate($formData)
-            ->on(SourceForm::ON_SUCCESS, function (SourceForm $form) {
+        /** @var ?Source $source */
+        $source = Source::on(NotificationsDatabase::get())
+            ->filter(Filter::all(
+                Filter::equal('name', KConfig::DEFAULT_NOTIFICATIONS_NAME . " ($clusterUuid)"),
+                Filter::equal('type', KConfig::DEFAULT_NOTIFICATIONS_TYPE)
+            ))
+            ->first();
+
+        if ($source !== null) {
+            $sourceForm->loadSource($source->id);
+        }
+
+        $sourceForm->populate($formData);
+
+        if ($source !== null) {
+            $sourceForm->on(SourceForm::ON_SUCCESS, function (SourceForm $form) {
+                $form->editSource();
+            });
+        } else {
+            $sourceForm->on(SourceForm::ON_SUCCESS, function (SourceForm $form) {
                 $form->addSource();
             });
+        }
 
         $sourceForm->ensureAssembled();
         $csrf = $sourceForm->getElement('CSRFToken');

--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -98,9 +98,7 @@ class ConfigController extends Controller
                                 Logger::error($e);
                                 Logger::error($e->getTraceAsString());
 
-                                $form->addMessage($e->getMessage());
-
-                                return;
+                                throw $e;
                             }
 
                             /** @var ?Source $source */
@@ -142,9 +140,7 @@ class ConfigController extends Controller
                             Logger::error($e);
                             Logger::error($e->getTraceAsString());
 
-                            $form->addMessage($e->getMessage());
-
-                            return;
+                            throw $e;
                         }
 
                         Notification::success(
@@ -217,9 +213,7 @@ class ConfigController extends Controller
                     Logger::error($e);
                     Logger::error($e->getTraceAsString());
 
-                    $form->addMessage($e->getMessage());
-
-                    return;
+                    throw $e;
                 }
 
                 Notification::success($this->translate('New configuration has successfully been stored'));

--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -28,6 +28,12 @@ class ConfigController extends Controller
 {
     protected bool $disableDefaultAutoRefresh = true;
 
+    public const PROMETHEUS_URL = 'prometheus.url';
+
+    public const PROMETHEUS_USERNAME = 'prometheus.username';
+
+    public const PROMETHEUS_PASSWORD = 'prometheus.password';
+
     public function init()
     {
         $this->assertPermission('config/modules');
@@ -181,34 +187,81 @@ class ConfigController extends Controller
     public function prometheusAction()
     {
         $db = Database::connection();
-        $dbConfig = KConfig::on($db)->filter(Filter::equal('key', 'prometheus.url'))->first();
+        $dbConfig = KConfig::on($db)->filter(
+            Filter::any(
+                Filter::equal('key', self::PROMETHEUS_URL),
+                Filter::equal('key', self::PROMETHEUS_USERNAME),
+                Filter::equal('key', self::PROMETHEUS_PASSWORD)
+            )
+        );
 
-//        $config = Config::module('kubernetes');
+        $data = [];
+
+        foreach ($dbConfig as $pair) {
+            switch ($pair->key) {
+                case self::PROMETHEUS_URL:
+                    $data['prometheus_url'] = $pair->value;
+                    break;
+                case self::PROMETHEUS_USERNAME:
+                    $data['prometheus_username'] = $pair->value;
+                    break;
+                case self::PROMETHEUS_PASSWORD:
+                    $data['prometheus_password'] = $pair->value;
+                    break;
+            }
+        }
+
         $form = (new PrometheusConfigForm())
-            ->populate(['prometheus_url' => $dbConfig->value])
-            ->on(PrometheusConfigForm::ON_SUCCESS, function ($form) use ($db, $dbConfig) {
+            ->populate($data)
+            ->on(PrometheusConfigForm::ON_SUCCESS, function ($form) use ($db, $data) {
                 if ($form->isLocked()) {
                     Notification::error($this->translate('Prometheus configuration is locked'));
                     return;
                 }
 
-//                $config->setSection('prometheus', $form->getValues());
-//                $config->saveIni();
-
-                if ($dbConfig) {
+                if (isset($data['prometheus_url'])) {
                     $db->update('config',
                         ['value' => $form->getValue('prometheus_url')],
-                        [$db->quoteIdentifier('key') . ' = ?' => 'prometheus.url']
+                        [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_URL]
                     );
                 } else {
                     $db->insert('config',
                         [
-                            $db->quoteIdentifier('key') => 'prometheus.url',
+                            $db->quoteIdentifier('key') => self::PROMETHEUS_URL,
                             'value'                     => $form->getValue('prometheus_url')
                         ]
                     );
                 }
 
+                if (isset($data['prometheus_username'])) {
+                    $db->update('config',
+                        ['value' => $form->getValue('prometheus_username')],
+                        [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_USERNAME]
+                    );
+                } else {
+                    $db->insert('config',
+                        [
+                            $db->quoteIdentifier('key') => self::PROMETHEUS_USERNAME,
+                            'value'                     => $form->getValue('prometheus_username')
+                        ]
+                    );
+                }
+
+                if (isset($data['prometheus_password'])) {
+                    $db->update('config',
+                        ['value' => $form->getValue('prometheus_password')],
+                        [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_PASSWORD]
+                    );
+                } else {
+                    $db->insert('config',
+                        [
+                            $db->quoteIdentifier('key') => self::PROMETHEUS_PASSWORD,
+                            'value'                     => $form->getValue('prometheus_password')
+                        ]
+                    );
+                }
+
+                $this->redirectNow('__REFRESH__');
 
                 Notification::success($this->translate('New configuration has successfully been stored'));
             })->handleRequest($this->getServerRequest());

--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -220,52 +220,52 @@ class ConfigController extends Controller
                         $data[$pair->key] = ['value' => $pair->value, 'locked' => $pair->locked];
                     }
 
-                    if ($data[self::PROMETHEUS_URL]['locked'] !== 'y') {
-                        if (isset($data[self::PROMETHEUS_URL])) {
-                            $db->update('config',
-                                ['value' => $form->getValue($this->fieldForForm(self::PROMETHEUS_URL))],
-                                [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_URL]
-                            );
-                        } else {
-                            $db->insert('config',
-                                [
-                                    $db->quoteIdentifier('key') => self::PROMETHEUS_URL,
-                                    'value'                     => $form->getValue($this->fieldForForm(self::PROMETHEUS_URL))
-                                ]
-                            );
-                        }
+                    if (isset($data[self::PROMETHEUS_URL]) && $data[self::PROMETHEUS_URL]['locked'] !== 'y') {
+                        $db->update(
+                            'config',
+                            ['value' => $form->getValue($this->fieldForForm(self::PROMETHEUS_URL))],
+                            [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_URL]
+                        );
+                    } elseif (! isset($data[self::PROMETHEUS_URL])) {
+                        $db->insert(
+                            'config',
+                            [
+                                $db->quoteIdentifier('key') => self::PROMETHEUS_URL,
+                                'value'                     => $form->getValue($this->fieldForForm(self::PROMETHEUS_URL))
+                            ]
+                        );
                     }
 
-                    if ($data[self::PROMETHEUS_USERNAME]['locked'] !== 'y') {
-                        if (isset($data[self::PROMETHEUS_USERNAME])) {
-                            $db->update('config',
-                                ['value' => $form->getValue($this->fieldForForm(self::PROMETHEUS_USERNAME))],
-                                [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_USERNAME]
-                            );
-                        } else {
-                            $db->insert('config',
-                                [
-                                    $db->quoteIdentifier('key') => self::PROMETHEUS_USERNAME,
-                                    'value'                     => $form->getValue($this->fieldForForm(self::PROMETHEUS_USERNAME))
-                                ]
-                            );
-                        }
+                    if (isset($data[self::PROMETHEUS_USERNAME]) && $data[self::PROMETHEUS_USERNAME]['locked'] !== 'y') {
+                        $db->update(
+                            'config',
+                            ['value' => $form->getValue($this->fieldForForm(self::PROMETHEUS_USERNAME))],
+                            [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_USERNAME]
+                        );
+                    } elseif (! isset($data[self::PROMETHEUS_USERNAME])) {
+                        $db->insert(
+                            'config',
+                            [
+                                $db->quoteIdentifier('key') => self::PROMETHEUS_USERNAME,
+                                'value'                     => $form->getValue($this->fieldForForm(self::PROMETHEUS_USERNAME))
+                            ]
+                        );
                     }
 
-                    if ($data[self::PROMETHEUS_PASSWORD]['locked'] !== 'y') {
-                        if (isset($data[self::PROMETHEUS_PASSWORD])) {
-                            $db->update('config',
-                                ['value' => $form->getValue($this->fieldForForm(self::PROMETHEUS_PASSWORD))],
-                                [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_PASSWORD]
-                            );
-                        } else {
-                            $db->insert('config',
-                                [
-                                    $db->quoteIdentifier('key') => self::PROMETHEUS_PASSWORD,
-                                    'value'                     => $form->getValue($this->fieldForForm(self::PROMETHEUS_PASSWORD))
-                                ]
-                            );
-                        }
+                    if (isset($data[self::PROMETHEUS_PASSWORD]) && $data[self::PROMETHEUS_PASSWORD]['locked'] !== 'y') {
+                        $db->update(
+                            'config',
+                            ['value' => $form->getValue($this->fieldForForm(self::PROMETHEUS_PASSWORD))],
+                            [$db->quoteIdentifier('key') . ' = ?' => self::PROMETHEUS_PASSWORD]
+                        );
+                    } elseif (! isset($data[self::PROMETHEUS_PASSWORD])) {
+                        $db->insert(
+                            'config',
+                            [
+                                $db->quoteIdentifier('key') => self::PROMETHEUS_PASSWORD,
+                                'value'                     => $form->getValue($this->fieldForForm(self::PROMETHEUS_PASSWORD))
+                            ]
+                        );
                     }
 
                     $db->commitTransaction();

--- a/application/forms/NotificationsConfigForm.php
+++ b/application/forms/NotificationsConfigForm.php
@@ -46,6 +46,7 @@ class NotificationsConfigForm extends CompatForm
             ->filter(Filter::equal('key', [
                 KConfig::NOTIFICATIONS_URL,
                 KConfig::NOTIFICATIONS_USERNAME,
+                KConfig::NOTIFICATIONS_PASSWORD,
                 KConfig::NOTIFICATIONS_KUBERNETES_WEB_URL
             ]))
             ->filter(Filter::equal('cluster_uuid', $clusterUuid));

--- a/application/forms/NotificationsConfigForm.php
+++ b/application/forms/NotificationsConfigForm.php
@@ -34,6 +34,11 @@ class NotificationsConfigForm extends CompatForm
             (string) Uuid::fromBytes(Cluster::on(Database::connection())->orderBy('uuid')->first()->uuid);
     }
 
+    public function getOldClusterUuid(): string
+    {
+        return $this->getPopulatedValue('old_cluster_uuid', $this->getClusterUuid());
+    }
+
     public function getKConfig(string $clusterUuid): array
     {
         $kconfig = [];
@@ -112,7 +117,7 @@ class NotificationsConfigForm extends CompatForm
     {
         $clusterUuid = $this->getClusterUuid();
 
-        if ($clusterUuid !== $this->getPopulatedValue('old_cluster_uuid', $clusterUuid)) {
+        if ($clusterUuid !== $this->getOldClusterUuid()) {
             $this->clearPopulatedValue('old_cluster_uuid');
             $this->clearPopulatedValue(static::transformKeyForForm(KConfig::NOTIFICATIONS_URL));
             $this->clearPopulatedValue(static::transformKeyForForm(KConfig::NOTIFICATIONS_KUBERNETES_WEB_URL));

--- a/application/forms/PrometheusConfigForm.php
+++ b/application/forms/PrometheusConfigForm.php
@@ -6,17 +6,58 @@ namespace Icinga\Module\Kubernetes\Forms;
 
 use Icinga\Module\Kubernetes\Common\Database;
 use Icinga\Module\Kubernetes\Controllers\ConfigController;
+use Icinga\Module\Kubernetes\Model\Cluster;
 use Icinga\Module\Kubernetes\Model\Config;
+use Icinga\Module\Kubernetes\Web\ClusterForm;
 use ipl\Html\Attributes;
 use ipl\Html\Html;
 use ipl\Stdlib\Filter;
 use ipl\Web\Compat\CompatForm;
+use Ramsey\Uuid\Uuid;
 
 class PrometheusConfigForm extends CompatForm
 {
     protected function assemble(): void
     {
-        if ($this->isLocked()) {
+        $clusterUuid = $this->getPopulatedValue('cluster_uuid') ??
+            (string) Uuid::fromBytes(Cluster::on(Database::connection())->orderBy('uuid')->first()->uuid);
+
+        $this->addElement('hidden', 'old_cluster_uuid', ['value' => $clusterUuid]);
+
+        if ($clusterUuid !== $this->getPopulatedValue('old_cluster_uuid', $clusterUuid)) {
+            $this->clearPopulatedValue('prometheus_url');
+        }
+
+        $dbConfig = Config::on(Database::connection())->filter(
+            Filter::all(
+                Filter::equal('cluster_uuid', Uuid::fromString($clusterUuid)->getBytes()),
+                Filter::any(
+                    Filter::equal('key', ConfigController::PROMETHEUS_URL),
+                    Filter::equal('key', ConfigController::PROMETHEUS_USERNAME),
+                    Filter::equal('key', ConfigController::PROMETHEUS_PASSWORD)
+                )
+            )
+        );
+
+        $data = [];
+
+        foreach ($dbConfig as $pair) {
+            $data[$pair->key] = ['value' => $pair->value, 'locked' => $pair->locked];
+        }
+
+        $this->addElement(
+            'select',
+            'cluster_uuid',
+            [
+                'required' => true,
+                'class'    => 'autosubmit',
+                'label'    => $this->translate('Cluster'),
+                'options'  => iterator_to_array(ClusterForm::yieldClusters()),
+                'value'    => $clusterUuid,
+            ],
+        );
+
+        if ($this->isLocked($clusterUuid)) {
             $this->addHtml(
                 Html::tag('div', Attributes::create(['class' => 'control-group']), [
                     Html::tag(
@@ -38,7 +79,8 @@ class PrometheusConfigForm extends CompatForm
             [
                 'label'    => $this->translate('URL'),
                 'required' => true,
-                'disabled' => $this->isLocked(),
+                'value'    => $data[ConfigController::PROMETHEUS_URL]['value'] ?? '',
+                'disabled' => $this->isLocked($clusterUuid),
             ]
         );
 
@@ -47,7 +89,8 @@ class PrometheusConfigForm extends CompatForm
             'prometheus_username',
             [
                 'label'    => $this->translate('Username'),
-                'disabled' => $this->isLocked(),
+                'value'    => $data[ConfigController::PROMETHEUS_USERNAME]['value'] ?? '',
+                'disabled' => $this->isLocked($clusterUuid),
             ]
         );
 
@@ -56,7 +99,8 @@ class PrometheusConfigForm extends CompatForm
             'prometheus_password',
             [
                 'label'    => $this->translate('Password'),
-                'disabled' => $this->isLocked(),
+                'value'    => $data[ConfigController::PROMETHEUS_PASSWORD]['value'] ?? '',
+                'disabled' => $this->isLocked($clusterUuid),
             ]
         );
 
@@ -65,22 +109,22 @@ class PrometheusConfigForm extends CompatForm
             'submit',
             [
                 'label'    => $this->translate('Save Changes'),
-                'disabled' => $this->isLocked()
+                'disabled' => $this->isLocked($clusterUuid),
             ]
         );
     }
 
-    public function isLocked(): bool
+    public function isLocked(string $clusterUuid): bool
     {
-        $config = Config::on(Database::connection());
-        $config->filter(Filter::equal('key', ConfigController::PROMETHEUS_URL));
+        $config = Config::on(Database::connection())
+            ->filter(
+                Filter::all(
+                    Filter::equal('cluster_uuid', Uuid::fromString($clusterUuid)->getBytes()),
+                    Filter::equal('key', ConfigController::PROMETHEUS_URL),
+                )
+            )
+            ->first();
 
-        $temp = $config->first();
-
-        if (isset($config->first()->locked) && $config->first()->locked === 'y') {
-            return true;
-        }
-
-        return false;
+        return $config->locked ?? false;
     }
 }

--- a/application/forms/PrometheusConfigForm.php
+++ b/application/forms/PrometheusConfigForm.php
@@ -1,0 +1,68 @@
+<?php
+
+/* Icinga for Kubernetes Web | (c) 2024 Icinga GmbH | AGPLv3 */
+
+namespace Icinga\Module\Kubernetes\Forms;
+
+use Icinga\Data\ResourceFactory;
+use ipl\Html\Attributes;
+use ipl\Html\Html;
+use ipl\Html\HtmlElement;
+use ipl\Web\Compat\CompatForm;
+use Icinga\Module\Kubernetes\Model\Config;
+use ipl\Stdlib\Filter;
+use Icinga\Module\Kubernetes\Common\Database;
+
+class PrometheusConfigForm extends CompatForm
+{
+    protected function assemble(): void
+    {
+        if ($this->isLocked()) {
+            $this->addHtml(
+                Html::tag('div', Attributes::create(['class' => 'control-group']), [
+                    Html::tag(
+                      'div',
+                        Attributes::create(['class' => 'control-label-group']),
+                    ),
+                    Html::tag(
+                        'p',
+                        Attributes::create(),
+                        "Prometheus configuration is provided via YAML."
+                    )
+                ])
+            );
+        }
+
+        $this->addElement(
+            'text',
+            'prometheus_url',
+            [
+                'label'    => $this->translate('URL'),
+                'required' => true,
+                'disabled' => $this->isLocked(),
+                'value'    => ''
+            ]
+        );
+
+        $this->addElement(
+            'submit',
+            'submit',
+            [
+                'label' => $this->translate('Save Changes'),
+                'disabled' => $this->isLocked()
+            ]
+        );
+    }
+
+    public function isLocked(): bool
+    {
+        $config = Config::on(Database::connection());
+        $config->filter(Filter::equal('key', 'prometheus.locked'));
+
+        if (isset($config->first()->value) && $config->first()->value === 'true') {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/application/forms/PrometheusConfigForm.php
+++ b/application/forms/PrometheusConfigForm.php
@@ -8,8 +8,6 @@ use Icinga\Module\Kubernetes\Common\Database;
 use Icinga\Module\Kubernetes\Model\Cluster;
 use Icinga\Module\Kubernetes\Model\Config as KConfig;
 use Icinga\Module\Kubernetes\Web\ClusterForm;
-use ipl\Html\Attributes;
-use ipl\Html\Html;
 use ipl\Stdlib\Filter;
 use ipl\Web\Compat\CompatForm;
 use Ramsey\Uuid\Uuid;
@@ -102,7 +100,8 @@ class PrometheusConfigForm extends CompatForm
                 'label'    => $this->translate('URL'),
                 'required' => true,
                 'value'    => $kconfig[KConfig::PROMETHEUS_URL]->value ?? null,
-                'disabled' => $kconfig[KConfig::PROMETHEUS_URL]->locked ?? false
+                'disabled' => $kconfig[KConfig::PROMETHEUS_URL]->locked ?? false,
+                'ignore'   => $kconfig[KConfig::PROMETHEUS_URL]->locked ?? false,
             ]
         );
 
@@ -112,7 +111,8 @@ class PrometheusConfigForm extends CompatForm
             [
                 'label'    => $this->translate('Username'),
                 'value'    => $kconfig[KConfig::PROMETHEUS_USERNAME]->value ?? null,
-                'disabled' => $kconfig[KConfig::PROMETHEUS_USERNAME]->locked ?? false
+                'disabled' => $kconfig[KConfig::PROMETHEUS_USERNAME]->locked ?? false,
+                'ignore'   => $kconfig[KConfig::PROMETHEUS_USERNAME]->locked ?? false,
             ]
         );
 
@@ -122,25 +122,10 @@ class PrometheusConfigForm extends CompatForm
             [
                 'label'    => $this->translate('Password'),
                 'value'    => $kconfig[KConfig::PROMETHEUS_PASSWORD]->value ?? null,
-                'disabled' => $kconfig[KConfig::PROMETHEUS_PASSWORD]->locked ?? false
+                'disabled' => $kconfig[KConfig::PROMETHEUS_PASSWORD]->locked ?? false,
+                'ignore'   => $kconfig[KConfig::PROMETHEUS_PASSWORD]->locked ?? false,
             ]
         );
-
-        if ($this->isLocked()) {
-            $this->addHtml(
-                Html::tag('div', Attributes::create(['class' => 'control-group']), [
-                    Html::tag(
-                        'div',
-                        new Attributes(['class' => 'control-label-group']),
-                    ),
-                    Html::tag(
-                        'p',
-                        null,
-                        'Prometheus configuration is provided via YAML.'
-                    )
-                ])
-            );
-        }
 
         $this->addElement(
             'submit',

--- a/application/forms/PrometheusConfigForm.php
+++ b/application/forms/PrometheusConfigForm.php
@@ -4,15 +4,13 @@
 
 namespace Icinga\Module\Kubernetes\Forms;
 
-use Icinga\Data\ResourceFactory;
+use Icinga\Module\Kubernetes\Common\Database;
 use Icinga\Module\Kubernetes\Controllers\ConfigController;
+use Icinga\Module\Kubernetes\Model\Config;
 use ipl\Html\Attributes;
 use ipl\Html\Html;
-use ipl\Html\HtmlElement;
-use ipl\Web\Compat\CompatForm;
-use Icinga\Module\Kubernetes\Model\Config;
 use ipl\Stdlib\Filter;
-use Icinga\Module\Kubernetes\Common\Database;
+use ipl\Web\Compat\CompatForm;
 
 class PrometheusConfigForm extends CompatForm
 {
@@ -22,7 +20,7 @@ class PrometheusConfigForm extends CompatForm
             $this->addHtml(
                 Html::tag('div', Attributes::create(['class' => 'control-group']), [
                     Html::tag(
-                      'div',
+                        'div',
                         Attributes::create(['class' => 'control-label-group']),
                     ),
                     Html::tag(
@@ -41,7 +39,6 @@ class PrometheusConfigForm extends CompatForm
                 'label'    => $this->translate('URL'),
                 'required' => true,
                 'disabled' => $this->isLocked(),
-                'value'    => ''
             ]
         );
 
@@ -51,7 +48,6 @@ class PrometheusConfigForm extends CompatForm
             [
                 'label'    => $this->translate('Username'),
                 'disabled' => $this->isLocked(),
-                'value'    => ''
             ]
         );
 
@@ -61,7 +57,6 @@ class PrometheusConfigForm extends CompatForm
             [
                 'label'    => $this->translate('Password'),
                 'disabled' => $this->isLocked(),
-                'value'    => ''
             ]
         );
 
@@ -69,7 +64,7 @@ class PrometheusConfigForm extends CompatForm
             'submit',
             'submit',
             [
-                'label' => $this->translate('Save Changes'),
+                'label'    => $this->translate('Save Changes'),
                 'disabled' => $this->isLocked()
             ]
         );

--- a/application/forms/PrometheusConfigForm.php
+++ b/application/forms/PrometheusConfigForm.php
@@ -5,6 +5,7 @@
 namespace Icinga\Module\Kubernetes\Forms;
 
 use Icinga\Data\ResourceFactory;
+use Icinga\Module\Kubernetes\Controllers\ConfigController;
 use ipl\Html\Attributes;
 use ipl\Html\Html;
 use ipl\Html\HtmlElement;
@@ -45,6 +46,26 @@ class PrometheusConfigForm extends CompatForm
         );
 
         $this->addElement(
+            'text',
+            'prometheus_username',
+            [
+                'label'    => $this->translate('Username'),
+                'disabled' => $this->isLocked(),
+                'value'    => ''
+            ]
+        );
+
+        $this->addElement(
+            'password',
+            'prometheus_password',
+            [
+                'label'    => $this->translate('Password'),
+                'disabled' => $this->isLocked(),
+                'value'    => ''
+            ]
+        );
+
+        $this->addElement(
             'submit',
             'submit',
             [
@@ -57,9 +78,11 @@ class PrometheusConfigForm extends CompatForm
     public function isLocked(): bool
     {
         $config = Config::on(Database::connection());
-        $config->filter(Filter::equal('key', 'prometheus.locked'));
+        $config->filter(Filter::equal('key', ConfigController::PROMETHEUS_URL));
 
-        if (isset($config->first()->value) && $config->first()->value === 'true') {
+        $temp = $config->first();
+
+        if (isset($config->first()->locked) && $config->first()->locked === 'y') {
             return true;
         }
 

--- a/configuration.php
+++ b/configuration.php
@@ -190,6 +190,15 @@ if (Module::exists('notifications')) {
     );
 }
 
+$this->provideConfigTab(
+    'prometheus',
+    [
+        'title' => $this->translate('Prometheus'),
+        'label' => $this->translate('Prometheus'),
+        'url'   => 'config/prometheus'
+    ]
+);
+
 $this->providePermission(
     Auth::SHOW_CONFIG_MAPS,
     $this->translate('Allow to show config maps')

--- a/library/Kubernetes/Model/Config.php
+++ b/library/Kubernetes/Model/Config.php
@@ -32,14 +32,15 @@ class Config extends Model
         return 'config';
     }
 
-    public function getKeyName(): string
+    public function getKeyName(): array
     {
-        return 'key';
+        return ['cluster_uuid', 'key'];
     }
 
     public function getColumns(): array
     {
         return [
+            'cluster_uuid',
             'key',
             'value',
             'locked'

--- a/library/Kubernetes/Model/Config.php
+++ b/library/Kubernetes/Model/Config.php
@@ -4,6 +4,8 @@
 
 namespace Icinga\Module\Kubernetes\Model;
 
+use Icinga\Module\Kubernetes\Model\Behavior\Uuid;
+use ipl\Orm\Behavior\Binary;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Model;
@@ -27,6 +29,22 @@ class Config extends Model
 
     public const NOTIFICATIONS_KUBERNETES_WEB_URL = 'notifications.kubernetes_web_url';
 
+    public const PROMETHEUS_URL = 'prometheus.url';
+
+    public const PROMETHEUS_USERNAME = 'prometheus.username';
+
+    public const PROMETHEUS_PASSWORD = 'prometheus.password';
+
+    public static function transformKeyForForm(string $key): string
+    {
+        return strtr($key, ['notifications.' => 'notifications_', 'prometheus.' => 'prometheus_']);
+    }
+
+    public static function transformKeyForDb(string $key): string
+    {
+        return strtr($key, ['notifications_' => 'notifications.', 'prometheus_' => 'prometheus.']);
+    }
+
     public function getTableName(): string
     {
         return 'config';
@@ -49,6 +67,10 @@ class Config extends Model
 
     public function createBehaviors(Behaviors $behaviors): void
     {
+        $behaviors->add(new Uuid([
+            'cluster_uuid'
+        ]));
+
         $behaviors->add(new BoolCast([
             'locked'
         ]));

--- a/library/Kubernetes/Web/ClusterForm.php
+++ b/library/Kubernetes/Web/ClusterForm.php
@@ -14,7 +14,7 @@ class ClusterForm extends CompatForm
 {
     public const ALL_CLUSTERS = '-';
 
-    protected function yieldClusters(): Generator
+    public static function yieldClusters(): Generator
     {
         $clusters = Cluster::on(Database::connection())
             ->columns(['uuid', 'name']);
@@ -37,7 +37,7 @@ class ClusterForm extends CompatForm
                 'label'    => $this->translate('Cluster'),
                 'options'  => [
                         static::ALL_CLUSTERS => $this->translate('All clusters'),
-                    ] + iterator_to_array($this->yieldClusters()),
+                    ] + iterator_to_array(ClusterForm::yieldClusters()),
             ],
         );
     }


### PR DESCRIPTION
Add a new config tab for Prometheus. If the config is provided via yaml the data is locked and the form is disabled.