### PR TITLE
Fix environment connection color

### DIFF
--- a/library/Kubernetes/Web/Environment.php
+++ b/library/Kubernetes/Web/Environment.php
@@ -225,11 +225,10 @@ class Environment extends BaseHtmlElement
                 new HtmlElement(
                     'path',
                     Attributes::create([
-                                           'stroke'       => 'black',
-                                           'stroke-width' => 1,
-                                           'fill'         => 'none',
-                                           'd'            => sprintf($path, $coordinate, $coordinate)
-                                       ])
+                        'stroke-width' => 1,
+                        'fill'         => 'none',
+                        'd'            => sprintf($path, $coordinate, $coordinate)
+                    ])
                 )
             );
         }

--- a/public/css/environment-widget.less
+++ b/public/css/environment-widget.less
@@ -57,6 +57,10 @@
     .svg-lines {
       width: @svg-edge-length;
       height: @svg-edge-length;
+
+      path {
+        stroke: @text-color;
+      }
     }
   }
 


### PR DESCRIPTION
Make the color depending on the theme using the css `text-color` variable.

**Light** mode

<img width="1647" alt="Screenshot 2025-05-02 at 10 12 18" src="https://github.com/user-attachments/assets/ca02f6f7-5d1c-411a-bdc6-a06eb4f6c52c" />

**Dark** mode

<img width="1647" alt="Screenshot 2025-05-02 at 10 12 53" src="https://github.com/user-attachments/assets/832c9148-f94e-4de3-ad2e-2bbaa919b86a" />

Closes #128 