### PR TITLE
Add outline to current object node

### DIFF
--- a/public/css/environment-widget.less
+++ b/public/css/environment-widget.less
@@ -156,6 +156,8 @@
 
     .self {
       cursor: default;
+      outline: .25em solid @icinga-blue; // 3px
+      outline-offset: 1px;
     }
 
     .summary .dependency-node-state-badges {


### PR DESCRIPTION
Add outline to the current object node of the environment widget, like in dependency module.