### PR TITLE
Use correct icons for pod's quality of service

### DIFF
--- a/library/Kubernetes/Web/PodListItem.php
+++ b/library/Kubernetes/Web/PodListItem.php
@@ -102,7 +102,8 @@ class PodListItem extends BaseListItem
                 $this->item->restart_policy
             ),
             new HorizontalKeyValue(
-                (new Icon('life-ring'))->addAttributes(['title' => $this->translate('Quality of Service')]),
+                (new Icon(self::QOS_ICONS[$this->item->qos]))
+                    ->addAttributes(['title' => $this->translate('Quality of Service')]),
                 $this->item->qos
             ),
             (new HorizontalKeyValue(


### PR DESCRIPTION
The array containing the **Quality of Service** icons was not used, so all different QoS showed the same icon. This PR fixes this problem by simply using the array again.