### PR TITLE
Fix: Kubernetes ActionList breaks IcingaDB ActionList

### DIFF
--- a/public/js/action-list.js
+++ b/public/js/action-list.js
@@ -13,7 +13,7 @@
 
     Icinga.Behaviors = Icinga.Behaviors || {};
 
-    class ActionList extends Icinga.EventListener {
+    class ActionListKubernetes extends Icinga.EventListener {
         constructor(icinga) {
             super(icinga);
 
@@ -594,6 +594,6 @@
         }
     }
 
-    Icinga.Behaviors.ActionList = ActionList;
+    Icinga.Behaviors.ActionListKubernetes = ActionListKubernetes;
 
 }(Icinga));


### PR DESCRIPTION
Rename JS class `ActionList` to `ActionListKubernetes` to not disturb IcingaDB action lists.