### PR TITLE
Fix: level indicator is visible in all view modes

### DIFF
--- a/public/css/icinga-state-reason.less
+++ b/public/css/icinga-state-reason.less
@@ -55,6 +55,13 @@
   }
 }
 
+.minimal-item-layout .caption,
+.default-item-layout .caption {
+  > .icinga-state-reason .row:before {
+    display: none;
+  }
+}
+
 .workload-rows .pod-rows,
 .pod-rows .container-rows {
   // level-indicator (1em) + state-ball margin (0.4em) + half state-ball size m (0.375em)


### PR DESCRIPTION
Hide the level indicator in the `minimal` and `common` view mode list items.