### PR TITLE
Fix search bar

### DIFF
--- a/library/Kubernetes/Web/Controller/Controller.php
+++ b/library/Kubernetes/Web/Controller/Controller.php
@@ -12,7 +12,7 @@ use ipl\Web\Filter\QueryString;
 
 abstract class Controller extends CompatController
 {
-    protected Filter\Rule $filter;
+    protected ?Filter\Rule $filter = null;
 
     /**
      * Default auto refresh interval in seconds


### PR DESCRIPTION
When searching just for a string the search bar threw an exception:
`Typed property Icinga\Module\Kubernetes\Web\Controller::$filter must not be accessed before initialization`

This is caused by checking whether the filter attribute is null without first initializing it as such.