### PR TITLE
Indicate table name to default sort column

### DIFF
--- a/application/controllers/EventsController.php
+++ b/application/controllers/EventsController.php
@@ -34,7 +34,10 @@ class EventsController extends ListController
 
     protected function getSortColumns(): array
     {
-        return ['event.created desc' => $this->translate('Created')];
+        return [
+            'event.last_seen desc' => $this->translate('Last Seen'),
+            'event.created desc' => $this->translate('Created')
+        ];
     }
 
     protected function getTitle(): string

--- a/application/controllers/NamespacesController.php
+++ b/application/controllers/NamespacesController.php
@@ -20,8 +20,8 @@ class NamespacesController extends ListController
     protected function getSortColumns(): array
     {
         return [
-            'namespaces.created desc' => $this->translate('Created'),
-            'namespaces.name'         => $this->translate('Name')
+            'namespace.created desc' => $this->translate('Created'),
+            'namespace.name'         => $this->translate('Name')
         ];
     }
 

--- a/library/Kubernetes/Model/Annotation.php
+++ b/library/Kubernetes/Model/Annotation.php
@@ -109,7 +109,7 @@ class Annotation extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name'];
+        return ['annotation.name'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Cluster.php
+++ b/library/Kubernetes/Model/Cluster.php
@@ -75,7 +75,7 @@ class Cluster extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name desc'];
+        return ['cluster.name desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/ConfigMap.php
+++ b/library/Kubernetes/Model/ConfigMap.php
@@ -68,7 +68,7 @@ class ConfigMap extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['config_map.created desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Container.php
+++ b/library/Kubernetes/Model/Container.php
@@ -87,7 +87,7 @@ class Container extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name'];
+        return ['container.name'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/ContainerMount.php
+++ b/library/Kubernetes/Model/ContainerMount.php
@@ -51,7 +51,7 @@ class ContainerMount extends Model
 
     public function getDefaultSort(): array
     {
-        return ['volume_name desc'];
+        return ['container_mount.volume_name desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/CronJob.php
+++ b/library/Kubernetes/Model/CronJob.php
@@ -106,7 +106,7 @@ class CronJob extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['cron_job.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/DaemonSet.php
+++ b/library/Kubernetes/Model/DaemonSet.php
@@ -105,7 +105,7 @@ class DaemonSet extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['daemon_set.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/DaemonSetCondition.php
+++ b/library/Kubernetes/Model/DaemonSetCondition.php
@@ -54,7 +54,7 @@ class DaemonSetCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['daemon_set_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/DaemonSetOwner.php
+++ b/library/Kubernetes/Model/DaemonSetOwner.php
@@ -53,7 +53,7 @@ class DaemonSetOwner extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name asc'];
+        return ['daemon_set_owner.name asc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Data.php
+++ b/library/Kubernetes/Model/Data.php
@@ -50,7 +50,7 @@ class Data extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name'];
+        return ['data.name'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Deployment.php
+++ b/library/Kubernetes/Model/Deployment.php
@@ -115,7 +115,7 @@ class Deployment extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['deployment.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/DeploymentCondition.php
+++ b/library/Kubernetes/Model/DeploymentCondition.php
@@ -57,7 +57,7 @@ class DeploymentCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['deployment_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/DeploymentOwner.php
+++ b/library/Kubernetes/Model/DeploymentOwner.php
@@ -53,7 +53,7 @@ class DeploymentOwner extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name asc'];
+        return ['deployment_owner.name asc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Event.php
+++ b/library/Kubernetes/Model/Event.php
@@ -100,7 +100,7 @@ class Event extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_seen desc'];
+        return ['event.last_seen desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/Ingress.php
+++ b/library/Kubernetes/Model/Ingress.php
@@ -79,7 +79,7 @@ class Ingress extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['ingress.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/InitContainer.php
+++ b/library/Kubernetes/Model/InitContainer.php
@@ -69,7 +69,7 @@ class InitContainer extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name'];
+        return ['init_container.name'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/Job.php
+++ b/library/Kubernetes/Model/Job.php
@@ -131,7 +131,7 @@ class Job extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['job.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/JobCondition.php
+++ b/library/Kubernetes/Model/JobCondition.php
@@ -57,7 +57,7 @@ class JobCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['job_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/JobOwner.php
+++ b/library/Kubernetes/Model/JobOwner.php
@@ -53,7 +53,7 @@ class JobOwner extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name asc'];
+        return ['job_owner.name asc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Label.php
+++ b/library/Kubernetes/Model/Label.php
@@ -113,7 +113,7 @@ class Label extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name'];
+        return ['label.name'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/NamespaceModel.php
+++ b/library/Kubernetes/Model/NamespaceModel.php
@@ -77,7 +77,7 @@ class NamespaceModel extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['namespace.created desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Node.php
+++ b/library/Kubernetes/Model/Node.php
@@ -128,7 +128,7 @@ class Node extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['node.created desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/NodeCondition.php
+++ b/library/Kubernetes/Model/NodeCondition.php
@@ -57,7 +57,7 @@ class NodeCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['node_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/PersistentVolume.php
+++ b/library/Kubernetes/Model/PersistentVolume.php
@@ -103,7 +103,7 @@ class PersistentVolume extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['persistent_volume.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/PersistentVolumeClaim.php
+++ b/library/Kubernetes/Model/PersistentVolumeClaim.php
@@ -111,7 +111,7 @@ class PersistentVolumeClaim extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['pvc.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/PersistentVolumeClaimCondition.php
+++ b/library/Kubernetes/Model/PersistentVolumeClaimCondition.php
@@ -57,7 +57,7 @@ class PersistentVolumeClaimCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['pvc_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Pod.php
+++ b/library/Kubernetes/Model/Pod.php
@@ -170,7 +170,7 @@ class Pod extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['pod.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/PodCondition.php
+++ b/library/Kubernetes/Model/PodCondition.php
@@ -57,7 +57,7 @@ class PodCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['pod_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/PodOwner.php
+++ b/library/Kubernetes/Model/PodOwner.php
@@ -53,7 +53,7 @@ class PodOwner extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name asc'];
+        return ['pod_owner.name asc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/ReplicaSet.php
+++ b/library/Kubernetes/Model/ReplicaSet.php
@@ -107,7 +107,7 @@ class ReplicaSet extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['replica_set.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/ReplicaSetCondition.php
+++ b/library/Kubernetes/Model/ReplicaSetCondition.php
@@ -54,7 +54,7 @@ class ReplicaSetCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['replica_set_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/ReplicaSetOwner.php
+++ b/library/Kubernetes/Model/ReplicaSetOwner.php
@@ -53,7 +53,7 @@ class ReplicaSetOwner extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name asc'];
+        return ['replica_set_owner.name asc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Selector.php
+++ b/library/Kubernetes/Model/Selector.php
@@ -46,7 +46,7 @@ class Selector extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name'];
+        return ['selector.name'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/Service.php
+++ b/library/Kubernetes/Model/Service.php
@@ -117,7 +117,7 @@ class Service extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['service.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/ServiceCondition.php
+++ b/library/Kubernetes/Model/ServiceCondition.php
@@ -56,7 +56,7 @@ class ServiceCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['service_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/SidecarContainer.php
+++ b/library/Kubernetes/Model/SidecarContainer.php
@@ -6,6 +6,11 @@ namespace Icinga\Module\Kubernetes\Model;
 
 class SidecarContainer extends Container
 {
+    public function getDefaultSort(): array
+    {
+        return ['sidecar_container.name'];
+    }
+
     public function getTableName(): string
     {
         return 'sidecar_container';

--- a/library/Kubernetes/Model/StatefulSet.php
+++ b/library/Kubernetes/Model/StatefulSet.php
@@ -109,7 +109,7 @@ class StatefulSet extends Model
 
     public function getDefaultSort(): array
     {
-        return ['created desc'];
+        return ['stateful_set.created desc'];
     }
 
     public function getKeyName(): string

--- a/library/Kubernetes/Model/StatefulSetCondition.php
+++ b/library/Kubernetes/Model/StatefulSetCondition.php
@@ -54,7 +54,7 @@ class StatefulSetCondition extends Model
 
     public function getDefaultSort(): array
     {
-        return ['last_transition desc'];
+        return ['stateful_set_condition.last_transition desc'];
     }
 
     public function getKeyName(): array

--- a/library/Kubernetes/Model/StatefulSetOwner.php
+++ b/library/Kubernetes/Model/StatefulSetOwner.php
@@ -53,7 +53,7 @@ class StatefulSetOwner extends Model
 
     public function getDefaultSort(): array
     {
-        return ['name asc'];
+        return ['stateful_set_owner.name asc'];
     }
 
     public function getKeyName(): array


### PR DESCRIPTION
The default sort column has to be one of the sort columns provided in the `ListController` extension. Otherwise in the `SortControl` it won't be the default value.