### PR TITLE
Fix namespace and resource name visibility

### DIFF
--- a/library/Kubernetes/View/BaseResourceRenderer.php
+++ b/library/Kubernetes/View/BaseResourceRenderer.php
@@ -53,7 +53,7 @@ abstract class BaseResourceRenderer implements ItemRenderer
             [
                 new HtmlElement(
                     'span',
-                    new Attributes(['class' => 'namespace-badge']),
+                    new Attributes(['class' => 'namespace-badge', 'title' => $item->namespace]),
                     new KIcon('namespace'),
                     new Text($item->namespace)
                 ),
@@ -63,7 +63,7 @@ abstract class BaseResourceRenderer implements ItemRenderer
                         new Text($item->name)
                     ),
                     Links::$kind($item),
-                    new Attributes(['class' => 'subject'])
+                    new Attributes(['class' => 'subject', 'title' => $item->name])
                 )
             ],
             new HtmlElement(

--- a/public/css/common.less
+++ b/public/css/common.less
@@ -103,6 +103,15 @@ pre {
   }
 }
 
+.object-detail {
+  .horizontal-key-value,
+  .vertical-key-value {
+    > .value {
+      white-space: normal;
+    }
+  }
+}
+
 .namespace-phase-active {
   color: @state-ok;
 }

--- a/public/css/lists.less
+++ b/public/css/lists.less
@@ -14,6 +14,20 @@ header .info-container {
   max-height: 7.5em; // 5 lines
 }
 
+// Override the default behavior from the ipl so that the detailed layout title behaves the same as in the
+// default layout. To understand the following look at the mixins at the link below. The properties are adjusted from
+// the 'detailed' case to how they are in the 'default' case.
+// https://github.com/Icinga/ipl-web/blob/1f5c1e5df037b9e7db771ea3daa316d6bdeb81c9/asset/css/item-layout.less#L8
+.item-layout.detailed-item-layout > .main > header > .title {
+  min-width: 0;
+  white-space: nowrap;
+  flex-wrap: nowrap;
+
+  > .subject {
+    .text-ellipsis();
+  }
+}
+
 .favored header .info-container .favor-icon {
   display: inline-block;
 }

--- a/public/css/widgets.less
+++ b/public/css/widgets.less
@@ -52,6 +52,19 @@
   white-space: normal;
 }
 
+// Only when the namespace badge has shrunk to a width of 8em the subject start shrinking.
+.default-item-layout:not(.minimal-item-layout),
+.detailed-item-layout {
+  .namespace-badge {
+    flex: 1 0 8em;
+    max-width: fit-content;
+  }
+
+  .subject {
+    flex: 0 1 auto;
+  }
+}
+
 .condition-table {
   display: block;
   overflow-x: auto;

--- a/public/css/widgets.less
+++ b/public/css/widgets.less
@@ -47,6 +47,11 @@
   .text-ellipsis();
 }
 
+// Show the full namespace in the detail page no matter the length
+.object-detail .namespace-badge {
+  white-space: normal;
+}
+
 .condition-table {
   display: block;
   overflow-x: auto;


### PR DESCRIPTION
Currently there are problems, regarding the visibility of longer namespaces and resource names. To ensure a better visibility the following changes were made in this PR:

1. Tooltips on hover for namespaces and resource names
2. The values and therefore namespace and resource name are displayed in full length in the detail page
3. The namespace can now grow significantly further in the common and detailed mode list view

resolve #161 