### PR TITLE
Support PHP 8.5

### DIFF
--- a/application/controllers/AssetsController.php
+++ b/application/controllers/AssetsController.php
@@ -44,7 +44,9 @@ class AssetsController extends Controller
         } else {
             $finfo = finfo_open(FILEINFO_MIME_TYPE);
             $mimeType = finfo_file($finfo, $asset);
-            finfo_close($finfo);
+            if (version_compare(PHP_VERSION, '8.5.0', '<')) {
+                finfo_close($finfo);
+            }
 
             $this->getResponse()
                 ->setHeader('ETag', $eTag)

--- a/application/controllers/AssetsController.php
+++ b/application/controllers/AssetsController.php
@@ -65,7 +65,7 @@ class AssetsController extends Controller
      * @param string $filename The name of the file to find
      * @param string $baseDir The base directory to search within
      *
-     * @return string|null The absolute path of the file if found and valid, or null otherwise
+     * @return ?string The absolute path of the file if found and valid, or null otherwise
      */
     protected function findFileInPath(string $filename, string $baseDir): ?string
     {

--- a/doc/02-Installation.md.d/From-Source.md
+++ b/doc/02-Installation.md.d/From-Source.md
@@ -8,7 +8,7 @@ Make sure you use `kubernetes` as the module name. The following requirements mu
 
 * [Icinga for Kubernetes](https://github.com/Icinga/icinga-kubernetes)
 * [Icinga Web 2](https://github.com/Icinga/icingaweb2) (≥2.9)
-* [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (≥0.13)
+* [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (≥0.19)
 * [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (≥0.12)
 
 <!-- {% include "02-Installation.md" %} -->

--- a/library/Kubernetes/Common/Database.php
+++ b/library/Kubernetes/Common/Database.php
@@ -14,6 +14,7 @@ use ipl\Sql\Expression;
 use ipl\Sql\QueryBuilder;
 use ipl\Sql\Select;
 use PDO;
+use Pdo\Mysql;
 
 abstract class Database
 {
@@ -45,7 +46,8 @@ abstract class Database
 
         $config->options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];
         if ($config->db === 'mysql') {
-            $config->options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
+            $config->options[Mysql::ATTR_INIT_COMMAND]
+                = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
                 . ",NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
         }
 

--- a/library/Kubernetes/Common/Factory.php
+++ b/library/Kubernetes/Common/Factory.php
@@ -136,7 +136,7 @@ abstract class Factory
      *
      * @param string $kind The kind to pluralize
      *
-     * @return string|null The pluralized kind or null if not found
+     * @return ?string The pluralized kind or null if not found
      */
     public static function pluralizeKind(string $kind): ?string
     {
@@ -215,10 +215,11 @@ abstract class Factory
      * Retrieves a resource by its kind.
      *
      * @param string $kind The kind of the resource
+     * @param ?Connection $db The connection to query
      *
-     * @return Query|null
+     * @return ?Query
      */
-    public static function fetchResource(string $kind, Connection $db = null): ?Query
+    public static function fetchResource(string $kind, ?Connection $db = null): ?Query
     {
         $kind = static::canonicalizeKind($kind);
 

--- a/library/Kubernetes/Common/ResourceDetails.php
+++ b/library/Kubernetes/Common/ResourceDetails.php
@@ -28,7 +28,7 @@ class ResourceDetails implements IteratorAggregate
 
     protected $resource;
 
-    public function __construct($resource, iterable $details = null)
+    public function __construct($resource, ?iterable $details = null)
     {
         $this->resource = $resource;
         $this->details = $details;

--- a/library/Kubernetes/Web/Widget/Environment/Environment.php
+++ b/library/Kubernetes/Web/Widget/Environment/Environment.php
@@ -45,10 +45,10 @@ class Environment extends BaseHtmlElement
      * Create Environment nodes
      *
      * @param Model $currentObject The object whose parents and children should be shown
-     * @param Query|null $parents The query for parents
-     * @param Query|null $children The query for children
-     * @param mixed|null $parentsFilter The filter for parents
-     * @param mixed|null $childrenFilter The filter for children
+     * @param ?Query $parents The query for parents
+     * @param ?Query $children The query for children
+     * @param ?mixed $parentsFilter The filter for parents
+     * @param ?mixed $childrenFilter The filter for children
      */
     public function __construct(
         protected Model $currentObject,


### PR DESCRIPTION
This PR updates the codebase for PHP 8.5 compatibility by addressing deprecations introduced in PHP 8.4/8.5.

### What changed
- Update implicitly nullable typed parameters to explicit nullable types.
- Update MySQL PDO constant usage. Use `Pdo\Mysql::ATTR_INIT_COMMAND`.
- Avoid deprecated `finfo_close()` call on PHP **8.5+**.
- Raise minimum IPL version to `0.19`.