### PR TITLE
Fix `ConditionRenderer` crash on null `last_transition`

### DIFF
--- a/library/Kubernetes/View/ConditionRenderer.php
+++ b/library/Kubernetes/View/ConditionRenderer.php
@@ -47,7 +47,9 @@ class ConditionRenderer implements ItemRenderer
 
     public function assembleExtendedInfo($item, HtmlDocument $info, string $layout): void
     {
-        $info->addHtml(new TimeAgo($item->last_transition->getTimestamp()));
+        if ($item->last_transition !== null) {
+            $info->addHtml(new TimeAgo($item->last_transition->getTimestamp()));
+        }
     }
 
     public function assemble($item, string $name, HtmlDocument $element, string $layout): false


### PR DESCRIPTION
`last_transition` is nullable on condition items, but `assembleExtendedInfo()` called `getTimestamp()` on it unconditionally. This caused a fatal `TypeError` and a blank detail page for any resource whose condition had never transitioned.

The fix adds a null check before constructing the `TimeAgo` widget.

fix #174 