### PR TITLE
Add Prometheus bearer token settings

### DIFF
--- a/application/forms/PrometheusConfigForm.php
+++ b/application/forms/PrometheusConfigForm.php
@@ -28,7 +28,9 @@ class PrometheusConfigForm extends CompatForm
                 KConfig::PROMETHEUS_URL,
                 KConfig::PROMETHEUS_INSECURE,
                 KConfig::PROMETHEUS_USERNAME,
-                KConfig::PROMETHEUS_PASSWORD
+                KConfig::PROMETHEUS_PASSWORD,
+                KConfig::PROMETHEUS_TOKEN,
+                KConfig::PROMETHEUS_TOKEN_FILE
             ]))
             ->filter(Filter::equal('cluster_uuid', $clusterUuid));
 
@@ -76,6 +78,8 @@ class PrometheusConfigForm extends CompatForm
             $this->clearPopulatedValue('prometheus_insecure');
             $this->clearPopulatedValue('prometheus_username');
             $this->clearPopulatedValue('prometheus_password');
+            $this->clearPopulatedValue('prometheus_token');
+            $this->clearPopulatedValue('prometheus_token_file');
         }
 
         $this->addElement('hidden', 'old_cluster_uuid', ['value' => $clusterUuid, 'ignore' => true]);
@@ -138,6 +142,28 @@ class PrometheusConfigForm extends CompatForm
                 'value'    => $kconfig[KConfig::PROMETHEUS_PASSWORD]->value ?? null,
                 'disabled' => $kconfig[KConfig::PROMETHEUS_PASSWORD]->locked ?? false,
                 'ignore'   => $kconfig[KConfig::PROMETHEUS_PASSWORD]->locked ?? false,
+            ]
+        );
+
+        $this->addElement(
+            'password',
+            KConfig::transformKeyForForm(KConfig::PROMETHEUS_TOKEN),
+            [
+                'label'    => $this->translate('Bearer Token'),
+                'value'    => $kconfig[KConfig::PROMETHEUS_TOKEN]->value ?? null,
+                'disabled' => $kconfig[KConfig::PROMETHEUS_TOKEN]->locked ?? false,
+                'ignore'   => $kconfig[KConfig::PROMETHEUS_TOKEN]->locked ?? false,
+            ]
+        );
+
+        $this->addElement(
+            'text',
+            KConfig::transformKeyForForm(KConfig::PROMETHEUS_TOKEN_FILE),
+            [
+                'label'    => $this->translate('Bearer Token File'),
+                'value'    => $kconfig[KConfig::PROMETHEUS_TOKEN_FILE]->value ?? null,
+                'disabled' => $kconfig[KConfig::PROMETHEUS_TOKEN_FILE]->locked ?? false,
+                'ignore'   => $kconfig[KConfig::PROMETHEUS_TOKEN_FILE]->locked ?? false,
             ]
         );
 

--- a/library/Kubernetes/Model/Config.php
+++ b/library/Kubernetes/Model/Config.php
@@ -37,6 +37,10 @@ class Config extends Model
 
     public const PROMETHEUS_PASSWORD = 'prometheus.password';
 
+    public const PROMETHEUS_TOKEN = 'prometheus.token';
+
+    public const PROMETHEUS_TOKEN_FILE = 'prometheus.token_file';
+
     public static function transformKeyForForm(string $key): string
     {
         return strtr($key, ['notifications.' => 'notifications_', 'prometheus.' => 'prometheus_']);


### PR DESCRIPTION
Adds support for authenticating against Prometheus with a bearer token or token file.

This keeps the existing basic auth support, but makes basic auth and bearer token auth mutually exclusive.
The daemon can now read `prometheus.token` or `prometheus.token_file`, persist locked Prometheus config values, and use them for Prometheus API requests. The web module adds the matching configuration fields.

ref Icinga/icinga-kubernetes#211